### PR TITLE
Disables orphans and younglings

### DIFF
--- a/code/datums/migrants/waves/itinerant_knight_wave.dm
+++ b/code/datums/migrants/waves/itinerant_knight_wave.dm
@@ -100,7 +100,7 @@
 	tutorial = "You are the squire of an itinerant knight, they have taken you under their custody as you have shown great talents, if you keep it on, you might become a knight yourself."
 	outfit = /datum/outfit/itinerant_squire
 	allowed_races = RACES_PLAYER_NONDISCRIMINATED
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 	exp_types_granted  = list(EXP_TYPE_COMBAT)
 
 	attribute_sheet = /datum/attribute_holder/sheet/job/migrant/itinerant_squire

--- a/code/datums/migrants/waves/magic_school_expedition.dm
+++ b/code/datums/migrants/waves/magic_school_expedition.dm
@@ -87,7 +87,7 @@
 	tutorial = "When the call went out for daring pupils to join a great overland trek from Kingsfield, you eagerly volunteered, visions of adventure, discovery, and excitement dancing in your mind. \
 	Of course, the creatures that lurk along the road seem just as eager... though perhaps for very different reasons."
 	outfit = /datum/outfit/magic_student
-	allowed_ages = list(AGE_CHILD)
+	allowed_ages = list(AGE_ADULT)
 	allowed_races = RACES_PLAYER_NONEXOTIC
 	allowed_patrons = list(/datum/patron/divine/noc)
 	exp_types_granted  = list(EXP_TYPE_MAGICK)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -63,7 +63,7 @@
 	var/dynamic_hair_suffix = ""//head > mask for head hair
 	var/dynamic_fhair_suffix = ""//mask > head for facial hair
 	var/list/allowed_sex = list(MALE, FEMALE)
-	var/list/allowed_ages = ALL_AGES_LIST_CHILD
+	var/list/allowed_ages = ALL_AGES_LIST
 	var/list/allowed_race = ALL_RACES_LIST
 	var/armor_class = ARMOR_CLASS_NONE
 	///Multiplies your standing speed by this value.

--- a/code/modules/events/personal/eora/adopt_orphan.dm
+++ b/code/modules/events/personal/eora/adopt_orphan.dm
@@ -4,7 +4,7 @@
 	typepath = /datum/round_event/adoption_call
 	weight = 7
 	earliest_start = 10 MINUTES
-	max_occurrences = 1
+	max_occurrences = 0//Encore edit- disabled because no playable children here please.
 	min_players = 35
 
 	tags = list(

--- a/code/modules/jobs/job_types/adventurer/types/wretch/reject.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/reject.dm
@@ -40,7 +40,7 @@
 		SPEC_ID_HALF_ORC,\
 		SPEC_ID_TIEFLING,\
 	)
-	allowed_ages = list(AGE_ADULT, AGE_CHILD)
+	allowed_ages = list(AGE_ADULT)
 	total_positions = 1
 	cmode_music = 'sound/music/cmode/nobility/combat_noble.ogg'
 	outfit = /datum/outfit/wretch/reject

--- a/code/modules/jobs/job_types/adventurer/types/wretch/rouschild.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/rouschild.dm
@@ -19,7 +19,7 @@
 /datum/job/advclass/wretch/rouschild
 	title = "Rouschild"
 	tutorial = "A child of the sewers, abandoned at birth, you were taken in by a colony of rous and raised as one of their own."
-	allowed_ages = ALL_AGES_LIST_CHILD
+	allowed_ages = ALL_AGES_LIST
 	allowed_races = RACES_PLAYER_ALL
 	outfit = /datum/outfit/wretch/rouschild
 	cmode_music = 'sound/music/cmode/adventurer/CombatOutlander2.ogg'

--- a/code/modules/jobs/job_types/apprentices/bapprentice.dm
+++ b/code/modules/jobs/job_types/apprentices/bapprentice.dm
@@ -32,7 +32,7 @@
 	job_bitflag = BITFLAG_CONSTRUCTOR
 
 	allowed_races = RACES_PLAYER_ALL
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 
 	outfit = /datum/outfit/bapprentice
 	can_be_apprentice = TRUE

--- a/code/modules/jobs/job_types/apprentices/clinicapprentice.dm
+++ b/code/modules/jobs/job_types/apprentices/clinicapprentice.dm
@@ -45,7 +45,7 @@
 	//a contrast to Akan gatekeeping knowledge, anyone is allowed to learn about Erdl's medicine and alchemy
 	//think of it how IRL age doesn't matter that much when it comes to attending university
 	//you can have 20 year olds in the same group as 60 year olds
-	allowed_ages = ALL_AGES_LIST_CHILD
+	allowed_ages = ALL_AGES_LIST
 	allowed_races = RACES_PLAYER_ALL
 	cmode_music = 'sound/music/cmode/towner/CombatTowner2.ogg'
 	outfit = /datum/outfit/clinicapprentice

--- a/code/modules/jobs/job_types/apprentices/prince.dm
+++ b/code/modules/jobs/job_types/apprentices/prince.dm
@@ -20,7 +20,7 @@
 	cmode_music = 'sound/music/cmode/nobility/combat_noble.ogg'
 
 	allowed_races = RACES_PLAYER_ROYALTY
-	allowed_ages = list(AGE_ADULT, AGE_CHILD)
+	allowed_ages = list(AGE_ADULT)
 	advclass_cat_rolls = list(CTAG_HEIR = 20)
 	honorary = "Prince"
 	honorary_f = "Princess"
@@ -48,7 +48,7 @@
 
 /datum/job/advclass/heir
 	inherit_parent_title = TRUE
-	allowed_ages = list(AGE_ADULT, AGE_CHILD)
+	allowed_ages = list(AGE_ADULT)
 	allowed_races = RACES_PLAYER_ROYALTY
 	exp_type = list(EXP_TYPE_NOBLE)
 	exp_types_granted = list(EXP_TYPE_NOBLE)

--- a/code/modules/jobs/job_types/apprentices/servant.dm
+++ b/code/modules/jobs/job_types/apprentices/servant.dm
@@ -57,7 +57,7 @@
 	cmode_music = 'sound/music/cmode/towner/CombatPrisoner.ogg'
 	can_have_apprentices = FALSE
 
-	allowed_ages = ALL_AGES_LIST_CHILD
+	allowed_ages = ALL_AGES_LIST
 	allowed_races = RACES_PLAYER_ALL
 
 	outfit = /datum/outfit/servant

--- a/code/modules/jobs/job_types/apprentices/shophand.dm
+++ b/code/modules/jobs/job_types/apprentices/shophand.dm
@@ -47,7 +47,7 @@
 	can_have_apprentices = FALSE
 
 	allowed_races = RACES_PLAYER_ALL
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 
 	outfit = /datum/outfit/shophand
 	display_order = JDO_SHOPHAND

--- a/code/modules/jobs/job_types/apprentices/squire.dm
+++ b/code/modules/jobs/job_types/apprentices/squire.dm
@@ -21,7 +21,7 @@
 	exp_types_granted = list(EXP_TYPE_GARRISON)
 
 	allowed_races = RACES_PLAYER_NONDISCRIMINATED
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 
 	outfit = /datum/outfit/squire
 
@@ -37,7 +37,7 @@
 	beltl = /obj/item/storage/keyring/manorguard
 
 /datum/job/advclass/squire
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 	allowed_races = RACES_PLAYER_NONDISCRIMINATED
 	exp_type = list(EXP_TYPE_GARRISON)
 	exp_types_granted = list(EXP_TYPE_GARRISON)

--- a/code/modules/jobs/job_types/apprentices/wapprentice.dm
+++ b/code/modules/jobs/job_types/apprentices/wapprentice.dm
@@ -36,7 +36,7 @@
 	spawn_positions = 2
 
 	allowed_races = RACES_PLAYER_ALL
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 	allowed_sexes = list(MALE, FEMALE)
 	cmode_music = "sound/music/cmode/adventurer/CombatSorcerer.ogg"
 	outfit = /datum/outfit/mageapprentice
@@ -49,7 +49,7 @@
 	can_be_apprentice = TRUE
 
 	allowed_races = RACES_PLAYER_ALL
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 	allowed_sexes = list(MALE, FEMALE)
 	allowed_patrons = list(/datum/patron/divine/noc, /datum/patron/inhumen/zizo)
 

--- a/code/modules/jobs/job_types/gallowband/bog_apprentice.dm
+++ b/code/modules/jobs/job_types/gallowband/bog_apprentice.dm
@@ -26,7 +26,7 @@
 	bypass_lastclass = TRUE
 	allowed_races = RACES_PLAYER_ALL
 	blacklisted_species = list(SPEC_ID_HALFLING)
-	allowed_ages = list(AGE_CHILD, AGE_ADULT)
+	allowed_ages = list(AGE_ADULT)
 	allowed_sexes = list(MALE, FEMALE)
 	outfit = /datum/outfit/bog_apprentice
 	is_foreigner = TRUE

--- a/code/modules/jobs/job_types/nobility/minor_noble.dm
+++ b/code/modules/jobs/job_types/nobility/minor_noble.dm
@@ -45,7 +45,7 @@
 	give_bank_account = 60
 	noble_income = 16
 	cmode_music = 'sound/music/cmode/nobility/combat_noble.ogg'
-	allowed_ages = ALL_AGES_LIST_CHILD
+	allowed_ages = ALL_AGES_LIST
 	spells = list(/datum/action/cooldown/spell/undirected/call_bird)
 	job_bitflag = BITFLAG_ROYALTY
 

--- a/code/modules/jobs/job_types/youngfolk/orphan.dm
+++ b/code/modules/jobs/job_types/youngfolk/orphan.dm
@@ -8,8 +8,8 @@
 	display_order = JDO_ORPHAN
 	faction = FACTION_TOWN
 	allowed_ages = list(AGE_CHILD)
-	total_positions = 12
-	spawn_positions = 12
+	total_positions = 0
+	spawn_positions = 0
 	bypass_lastclass = TRUE
 	can_have_apprentices = FALSE
 	can_be_apprentice = TRUE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_EMPTY(roundstart_species)
 	/// if alien colors are disabled, this is the color that will be used by that race
 	var/default_color = "#FFF"
 	/// List of ages that can be selected in prefs for this species
-	var/list/possible_ages = ALL_AGES_LIST_CHILD
+	var/list/possible_ages = ALL_AGES_LIST
 	/// Whether or not this species has sexual characteristics
 	var/sexes = TRUE
 	/// Whether this species a requires donator subscription to access, we removed all donator restrictions for species, but it's here if we ever want to reenable them or smth.

--- a/code/modules/mob/living/carbon/human/species_types/demihumans/_demihuman.dm
+++ b/code/modules/mob/living/carbon/human/species_types/demihumans/_demihuman.dm
@@ -51,7 +51,7 @@
 	species_traits = list(EYECOLOR, HAIR ,FACEHAIR, LIPS, STUBBLE, OLDGREY)
 	default_features = MANDATORY_FEATURE_LIST
 	use_skintones = TRUE
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 	disliked_food = NONE
 	liked_food = NONE
 	changesource_flags = WABBAJACK

--- a/code/modules/mob/living/carbon/human/species_types/elf/elfd.dm
+++ b/code/modules/mob/living/carbon/human/species_types/elf/elfd.dm
@@ -53,7 +53,7 @@
 	use_skintones = 1
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 	changesource_flags = WABBAJACK
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mem.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/ft.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/elf/elfs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/elf/elfs.dm
@@ -42,7 +42,7 @@
 	use_skintones = 1
 	disliked_food = NONE
 	liked_food = NONE
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 	changesource_flags = WABBAJACK
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/met.dmi'
 	limbs_icon_f = 'icons/roguetown/mob/bodies/f/ft.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/halfling/_halfling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/halfling/_halfling.dm
@@ -36,7 +36,7 @@
 
 	use_skintones = TRUE
 
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 
 	changesource_flags = WABBAJACK
 

--- a/code/modules/mob/living/carbon/human/species_types/harpy/_harpy.dm
+++ b/code/modules/mob/living/carbon/human/species_types/harpy/_harpy.dm
@@ -40,7 +40,7 @@
 	inherent_sheet = /datum/attribute_holder/sheet/job/species/harpy
 
 	use_skintones = TRUE
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 	changesource_flags = WABBAJACK
 
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/harpy.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/human/humen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/human/humen.dm
@@ -39,7 +39,7 @@
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 	use_skintones = TRUE
 
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 
 	changesource_flags = WABBAJACK
 

--- a/code/modules/mob/living/carbon/human/species_types/other/halfdrow.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halfdrow.dm
@@ -37,7 +37,7 @@
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 
 	use_skintones = TRUE
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 
 	changesource_flags = WABBAJACK
 

--- a/code/modules/mob/living/carbon/human/species_types/other/halfelf.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halfelf.dm
@@ -44,7 +44,7 @@
 	inherent_traits = list(TRAIT_NOMOBSWAP)
 
 	use_skintones = TRUE
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 
 	changesource_flags = WABBAJACK
 

--- a/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/halforc.dm
@@ -53,7 +53,7 @@
 
 	use_skintones = 1
 
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 	changesource_flags = WABBAJACK
 
 	limbs_icon_m = 'icons/roguetown/mob/bodies/m/mt_muscular.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/other/tiefling.dm
+++ b/code/modules/mob/living/carbon/human/species_types/other/tiefling.dm
@@ -50,7 +50,7 @@
 	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_NOFIRE)
 	use_skintones = TRUE
 
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 
 	changesource_flags = WABBAJACK
 

--- a/code/modules/mob/living/carbon/human/species_types/rakshari/_rakshari.dm
+++ b/code/modules/mob/living/carbon/human/species_types/rakshari/_rakshari.dm
@@ -34,7 +34,7 @@
 	use_skintones = TRUE
 	default_color = "FFFFFF"
 
-	possible_ages = NORMAL_AGES_LIST_CHILD
+	possible_ages = NORMAL_AGES_LIST
 
 	species_traits = list(EYECOLOR, HAIR, FACEHAIR, OLDGREY)
 	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_KITTEN_MOM)


### PR DESCRIPTION
For inscrutable reasons, Vanderlin uses younglings still. Why? Fuck knows, but for obvious reasons, they're going to be disabled here. I imagine they exist purely to sell some comedic grim angle of punting orphans into the moat as a pastime. These sorts of things wouldn't fly here, so bye bye children.

Extracting them entirely from the code would be a headache right now but for now this makes them inaccessible from a player perspective at least.