### PR TITLE
Disables default ruler requirement

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -364,7 +364,7 @@
 	default = FALSE
 
 /datum/config_entry/flag/ruler_required
-	config_entry_value = TRUE
+	config_entry_value = FALSE
 	default = FALSE
 
 /datum/config_entry/flag/starvation_death


### PR DESCRIPTION
title. not every round needs a regent