### PR TITLE
Nerfs Status Effect Stat Malus

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -67,8 +67,8 @@ SUBSYSTEM_DEF(nightshift)
 	if(todd == DAWN)
 		if(HAS_TRAIT(src, TRAIT_VAMP_DREAMS))
 			apply_status_effect(/datum/status_effect/debuff/vamp_dreams)
-		if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))
-			add_stress(/datum/stress_event/night_owl_dawn)
+	/*	if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))
+			add_stress(/datum/stress_event/night_owl_dawn)	*/
 
 	if(todd == NIGHT)
 		if(HAS_TRAIT(src, TRAIT_NIGHT_OWL))

--- a/code/datums/status_effects/rogue/debuff.dm
+++ b/code/datums/status_effects/rogue/debuff.dm
@@ -29,7 +29,7 @@
 /datum/status_effect/debuff/hungryt2
 	id = "hungryt2"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/hungryt2
-	effectedstats = list(STAT_SPEED = -4, STAT_STRENGTH = -2, STAT_CONSTITUTION = -2, STAT_ENDURANCE = -1)
+	effectedstats = list(STAT_SPEED = -2, STAT_STRENGTH = -2, STAT_CONSTITUTION = -2, STAT_ENDURANCE = -1)
 	duration = 100
 
 /atom/movable/screen/alert/status_effect/debuff/hungryt2
@@ -52,7 +52,7 @@
 /datum/status_effect/debuff/hungryt3
 	id = "hungryt3"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/hungryt3
-	effectedstats = list(STAT_SPEED = -6, STAT_STRENGTH = -6, STAT_CONSTITUTION = -6, STAT_ENDURANCE = -6)
+	effectedstats = list(STAT_SPEED = -3, STAT_STRENGTH = -3, STAT_CONSTITUTION = -3, STAT_ENDURANCE = -3)
 	duration = 100
 
 /atom/movable/screen/alert/status_effect/debuff/hungryt3
@@ -131,7 +131,7 @@
 /datum/status_effect/debuff/thirstyt2
 	id = "thirsty2"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/thirstyt2
-	effectedstats = list(STAT_SPEED = -4, STAT_ENDURANCE = -4)
+	effectedstats = list(STAT_SPEED = -2, STAT_ENDURANCE = -2)
 	duration = 100
 
 /atom/movable/screen/alert/status_effect/debuff/thirstyt2
@@ -154,7 +154,7 @@
 /datum/status_effect/debuff/thirstyt3
 	id = "thirsty3"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/thirstyt3
-	effectedstats = list(STAT_STRENGTH = -6, STAT_SPEED = -6, STAT_ENDURANCE = -6)
+	effectedstats = list(STAT_STRENGTH = -3, STAT_SPEED = -3, STAT_ENDURANCE = -3)
 	duration = 100
 
 /atom/movable/screen/alert/status_effect/debuff/thirstyt3
@@ -309,7 +309,6 @@
 /datum/status_effect/debuff/sleepytime
 	id = "sleepytime"
 	alert_type = /atom/movable/screen/alert/status_effect/debuff/sleepytime
-	effectedstats = list(STAT_SPEED = -2, STAT_ENDURANCE = -2)
 
 /datum/status_effect/debuff/sleepytime/on_apply()
 	. = ..()

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -559,10 +559,12 @@
 	stress_change = 2
 	desc = span_red("One of my brats are calling for help! Another mess I have to clean up no doubt...")
 
+/*
 /datum/stress_event/night_owl_dawn
 	desc = span_warning("I don't like the dae..")
 	stress_change = 1
 	timer = 10 MINUTES
+*/
 
 /datum/stress_event/hithead
 	timer = 2 MINUTES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Lessens the stat malus you get from Hungry and Thirsty effects.
- Completely removes stat malus from Tired.
- Removes the stress gain during daytime from the Night Owl virtue.

## Why It's Good For The Game

- Hungry and Thirsty penalties are really heavy handed, going up to -6 in like four or five different stats as it progresses.
- Tired is a predictable status effect you get as the day/night cycle ticks over, telling you that you can sleep. A -2 penalty to speed and endurance is incredibly obstructive when you can go to sleep, wake up, and then get the debuff again 30 seconds later because day/night changed again.
- You pay points to get a stress reduction at night time. The description of the virtue makes no mention of granting you stress during the daytime to compensate. Goodbye.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
