### PR TITLE
Loadout Selection Fix

### DIFF
--- a/code/modules/client/preferences/_preferences.dm
+++ b/code/modules/client/preferences/_preferences.dm
@@ -1724,6 +1724,9 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 						loadouts_available,
 					)
 					var/loadout_number = href_list["loadout_number"]
+					if(loadout_input == "None")
+						set_loadout(user, loadout_number, loadout_input)
+						return
 					// Re-validate on submission in case of href manipulation
 					var/datum/loadout_item/chosen = loadouts_available[loadout_input]
 					var/datum/loadout_item/chosen_singleton = GLOB.loadout_items[chosen]
@@ -2510,7 +2513,7 @@ GLOBAL_LIST_INIT(name_adjustments, list())
 		return FALSE
 
 	if(loadout == "None")
-		vars["loadout[loadout]"] = null
+		vars["loadout[loadout_number]"] = null
 		to_chat(user, span_notice("Who needs stuff anyway?"))
 	else
 		if(!(loadout in GLOB.loadout_items))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Fixes #124 
Have to save the character to refresh the loadout, but it does in fact select 'none' now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
sometimes you just don't want a loadout!

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: being unable to select "None" for loadouts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
