### PR TITLE
More Miracle Fixes

### DIFF
--- a/code/datums/faith/devotion_subtypes.dm
+++ b/code/datums/faith/devotion_subtypes.dm
@@ -44,9 +44,9 @@
 
 /datum/devotion/divine/gani
 	miracles = list(
-		CLERIC_T0 = /datum/action/cooldown/spell/healing,
+		CLERIC_T0 = /datum/action/cooldown/spell/healing/greater,
 		CLERIC_T1 = /datum/action/cooldown/spell/undirected/bless_crops,
-		CLERIC_T2 = list(/datum/action/cooldown/spell/undirected/beast_sense, /datum/action/cooldown/spell/healing/greater, /datum/action/cooldown/spell/aoe/abrogation),
+		CLERIC_T2 = list(/datum/action/cooldown/spell/undirected/beast_sense, /datum/action/cooldown/spell/undirected/blade_ward/miracle/earth, /datum/action/cooldown/spell/aoe/abrogation),
 		CLERIC_T3 = list(/datum/action/cooldown/spell/beast_tame, /datum/action/cooldown/spell/undirected/troll_shape),
 
 	)
@@ -61,7 +61,7 @@
 	miracles = list(
 		CLERIC_T0 = /datum/action/cooldown/spell/healing,
 		CLERIC_T1 = /datum/action/cooldown/spell/projectile/swordfish,
-		CLERIC_T2 = list(/datum/action/cooldown/spell/undirected/conjure_item/summon_trident/miracle, /datum/action/cooldown/spell/undirected/blade_ward, /datum/action/cooldown/spell/aoe/abrogation),
+		CLERIC_T2 = list(/datum/action/cooldown/spell/undirected/conjure_item/summon_trident/miracle, /datum/action/cooldown/spell/undirected/blade_ward/miracle/frost, /datum/action/cooldown/spell/aoe/abrogation),
 		CLERIC_T3 = /datum/action/cooldown/spell/persistence,
 	)
 	viable_tasks = list(
@@ -87,7 +87,7 @@
 	miracles = list(
 		CLERIC_T0 = /datum/action/cooldown/spell/healing,
 		CLERIC_T1 = /datum/action/cooldown/spell/undirected/call_to_arms,
-		CLERIC_T2 = list(/datum/action/cooldown/spell/undirected/divine_strike, /datum/action/cooldown/spell/undirected/blade_ward, /datum/action/cooldown/spell/aoe/abrogation),
+		CLERIC_T2 = list(/datum/action/cooldown/spell/undirected/divine_strike, /datum/action/cooldown/spell/undirected/blade_ward/miracle/frost, /datum/action/cooldown/spell/aoe/abrogation),
 		CLERIC_T3 = /datum/action/cooldown/spell/ocean_embrace,
 	)
 	traits = list(TRAIT_DIVINE_SERVANT)
@@ -107,10 +107,10 @@
 
 /datum/devotion/divine/erdl
 	miracles = list(
-		CLERIC_T0 = list(/datum/action/cooldown/spell/healing, /datum/action/cooldown/spell/undirected/conjure_item/summon_leech/erdl),
+		CLERIC_T0 = list(/datum/action/cooldown/spell/healing/greater, /datum/action/cooldown/spell/undirected/conjure_item/summon_leech/erdl),
 		CLERIC_T1 = /datum/action/cooldown/spell/diagnose/holy,
-		CLERIC_T2 = list(/datum/action/cooldown/spell/attach_bodypart, /datum/action/cooldown/spell/healing/greater, /datum/action/cooldown/spell/aoe/abrogation),
-		CLERIC_T3 = /datum/action/cooldown/spell/cure_rot,
+		CLERIC_T2 = list(/datum/action/cooldown/spell/attach_bodypart, /datum/action/cooldown/spell/cure_rot, /datum/action/cooldown/spell/aoe/abrogation),
+		CLERIC_T3 = /datum/action/cooldown/spell/revive,
 	)
 	viable_tasks = list(
 		/datum/devotion_task/erdl_heal,

--- a/code/modules/spells/spell_types/pointed/hammer_fall.dm
+++ b/code/modules/spells/spell_types/pointed/hammer_fall.dm
@@ -17,23 +17,6 @@
 	cooldown_time = 3 MINUTES
 	spell_cost = 75
 
-	var/static/list/hammer_weapons = typecacheof(list(
-		/obj/item/weapon/hammer,
-		/obj/item/weapon/mace/goden/steel/warhammer,
-		/obj/item/weapon/mace/warhammer,
-	))
-
-/datum/action/cooldown/spell/hammer_fall/can_cast_spell(feedback)
-	. = ..()
-	if(!.)
-		return
-	for(var/obj/item/I in owner.held_items)
-		if(is_type_in_typecache(I.type, hammer_weapons))
-			break
-		if(feedback)
-			to_chat(owner, "I need a hammer to cast this.")
-		return FALSE
-
 /datum/action/cooldown/spell/hammer_fall/before_cast(atom/cast_on)
 	. = ..()
 	if(. & SPELL_CANCEL_CAST)

--- a/code/modules/spells/spell_types/undirected/blade_ward.dm
+++ b/code/modules/spells/spell_types/undirected/blade_ward.dm
@@ -60,6 +60,10 @@
 	var/mob/living/target = owner
 	target.cut_overlay(ward)
 
+/datum/action/cooldown/spell/undirected/blade_ward/miracle
+	name = "Divine Blade Ward"
+	desc = "This is a placeholder. If you've been given this spell, it's by mistake, please make a bug report on GitHub."
+
 /datum/action/cooldown/spell/undirected/blade_ward/miracle/frost
 	name = "Frost's Aegis"
 	desc = "Call upon the powers of Frost to fortify you against blows for a time."

--- a/code/modules/spells/spell_types/undirected/blade_ward.dm
+++ b/code/modules/spells/spell_types/undirected/blade_ward.dm
@@ -59,3 +59,19 @@
 	. = ..()
 	var/mob/living/target = owner
 	target.cut_overlay(ward)
+
+/datum/action/cooldown/spell/undirected/blade_ward/miracle/frost
+	name = "Frost's Aegis"
+	desc = "Call upon the powers of Frost to fortify you against blows for a time."
+	spell_type = SPELL_MIRACLE
+	antimagic_flags = MAGIC_RESISTANCE_HOLY
+	associated_skill = /datum/attribute/skill/magic/holy
+	invocation = "Let my flesh harden like ice!"
+
+/datum/action/cooldown/spell/undirected/blade_ward/miracle/earth
+	name = "Earth's Bulwark"
+	desc = "Call upon the powers of Earth to fortify you against blows for a time."
+	spell_type = SPELL_MIRACLE
+	antimagic_flags = MAGIC_RESISTANCE_HOLY
+	associated_skill = /datum/attribute/skill/magic/holy
+	invocation = "Let my flesh harden like stone!"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Removes the blacksmith hammer requirement from Hammerfall for Goler Kanh clergy.
- Removes Lesser Heal from Gani and Erdl clergy, since they already had Greater Heal and it made the former obsolete.
- Adds Revive as a maximum tier miracle for Erdl.
- Adds two miracle subtypes for Blade Ward, for Frost (Mjallidhorn and Mordsol) and Earth (Gani).
- Replaces the wizard versions of Blade Ward on Mjallidhorn and Mordsol clergy for the Frost miracle version.
- Adds the Earth miracle version of Blade Ward to Gani clergy.

## Why It's Good For The Game

- I WILL make Goler Kanh clergy into one-man siege weapons.
- Removal of excessive and obsolete spells from patrons to tidy up their lists.
- More flavour is good.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
