### PR TITLE
Headeater and Merchantry Tweaks

### DIFF
--- a/code/game/objects/items/natural/animals.dm
+++ b/code/game/objects/items/natural/animals.dm
@@ -156,7 +156,7 @@
 	name = "volf head"
 	desc = "The severed head of a fearsome volf."
 	icon_state = "volfhead"
-	sellprice = 5
+	sellprice = 10
 	blood_value = BLOOD_VOLUME_SURVIVE
 	item_weight = 1.2 KILOGRAMS
 
@@ -164,7 +164,7 @@
 	name = "saiga head"
 	desc = "The severed head of a proud saiga."
 	icon_state = "saigahead"
-	sellprice = 3
+	sellprice = 6
 	blood_value = BLOOD_VOLUME_BAD
 	item_weight = 1.2 KILOGRAMS
 
@@ -175,7 +175,7 @@
 	grid_height = 96
 	grid_width = 96
 	w_class = WEIGHT_CLASS_BULKY
-	sellprice = 20
+	sellprice = 40
 	blood_value = BLOOD_VOLUME_OKAY
 	item_weight = 2.1 KILOGRAMS
 
@@ -186,18 +186,18 @@
 	name = "troll head"
 	desc = "The severed head of a once mighty warrior troll."
 	icon_state = "trollhead_axe"
-	sellprice = 30
+	sellprice = 60
 
 /obj/item/natural/head/troll/cave
 	name = "cave troll head"
 	icon_state = "cavetrollhead"
-	sellprice = 45
+	sellprice = 90
 
 /obj/item/natural/head/rous
 	name = "rous head"
 	desc = "The severed head of an unusually large rat."
 	icon_state = "roushead"
-	sellprice = 2
+	sellprice = 4
 	meat_to_give = /obj/item/reagent_containers/food/snacks/meat/mince/beef
 	item_weight = 500 GRAMS
 
@@ -206,7 +206,7 @@
 	desc = "The head of a terrifying direbear."
 	icon_state = "direbearhead"
 	layer = 3.1
-	sellprice = 20
+	sellprice = 40
 	blood_value = BLOOD_VOLUME_SAFE
 	item_weight = 1.6 KILOGRAMS
 
@@ -216,7 +216,7 @@
 	icon_state = "foxhead"
 	layer = 3.1
 	grid_height = 32
-	sellprice = 12 // fur trade
+	sellprice = 24 // fur trade
 	blood_value = BLOOD_VOLUME_SURVIVE
 	item_weight = 400 GRAMS
 
@@ -224,7 +224,7 @@
 	name = "beespider head"
 	desc = "The severed head of a venomous beespider."
 	icon_state = "spiderhead"
-	sellprice = 6
+	sellprice = 12
 	meat_to_give = /obj/item/reagent_containers/food/snacks/meat/strange
 	item_weight = 200 GRAMS
 
@@ -232,7 +232,7 @@
 	name = "bogbug head"
 	desc = "The severed head of a gross bogbug."
 	icon_state = "boghead"
-	sellprice = 10
+	sellprice = 20
 	meat_to_give = /obj/item/reagent_containers/food/snacks/meat/strange
 	item_weight = 400 GRAMS
 
@@ -242,7 +242,7 @@
 	icon_state = "molehead"
 	grid_height = 96
 	grid_width = 96
-	sellprice = 8
+	sellprice = 16
 	blood_value = BLOOD_VOLUME_SURVIVE
 	item_weight = 765 GRAMS
 
@@ -253,7 +253,7 @@
 	name = "gote head"
 	desc = "The severed head of a fiery gote."
 	icon_state = "gotehead"
-	sellprice = 3
+	sellprice = 6
 	blood_value = BLOOD_VOLUME_SURVIVE / 2
 	item_weight = 1.1 KILOGRAMS
 

--- a/code/game/objects/structures/fake_machines/headeater.dm
+++ b/code/game/objects/structures/fake_machines/headeater.dm
@@ -1,7 +1,7 @@
 
 /obj/structure/fake_machine/headeater
 	name = "\improper HEADEATER"
-	desc = "A machine that feeds on certain heads for coin. Worth more than selling to the merchantry."
+	desc = "A machine that feeds on certain heads for coin. Worth less than selling to the merchantry."
 	icon = 'icons/roguetown/misc/machines.dmi'
 	icon_state = "headeater"
 	density = FALSE
@@ -27,7 +27,7 @@
 
 	visible_message(span_notice("[src] consumes [I], spitting out a reward!"), vision_distance = COMBAT_MESSAGE_RANGE)
 	playsound(src, 'sound/gore/flesh_eat_03.ogg', 100,)
-	var/reward = round(I.sellprice * 1.25)
+	var/reward = round(I.sellprice * 0.65)
 	budget2change(reward, user)
 	record_round_statistic(STATS_HEADEATER_EXPORTS, reward)
 	qdel(I)

--- a/code/modules/mob/living/carbon/human/npc/goblin.dm
+++ b/code/modules/mob/living/carbon/human/npc/goblin.dm
@@ -123,7 +123,7 @@
 	dismemberable = 0
 
 /obj/item/bodypart/head/goblin
-	sellprice = 5
+	sellprice = 10
 
 /obj/item/bodypart/head/goblin/update_icon_dropped()
 	return

--- a/code/modules/mob/living/carbon/human/npc/orc/_orc.dm
+++ b/code/modules/mob/living/carbon/human/npc/orc/_orc.dm
@@ -77,7 +77,7 @@
 /obj/item/bodypart/l_leg/orc
 	dismemberable = 1
 /obj/item/bodypart/head/orc
-	sellprice = 10
+	sellprice = 20
 
 /obj/item/bodypart/head/orc/update_icon_dropped()
 	return

--- a/code/modules/mob/living/carbon/human/npc/rousman.dm
+++ b/code/modules/mob/living/carbon/human/npc/rousman.dm
@@ -112,7 +112,7 @@ GLOBAL_LIST_EMPTY(rousman_ambush_objects)
 /////////////////////////////////////////////////////////////////////////////
 
 /obj/item/bodypart/head/rousman
-	sellprice = 5
+	sellprice = 10
 
 /obj/item/bodypart/head/rousman/update_icon_dropped()
 	return

--- a/code/modules/mob/living/carbon/human/npc/skeleton/_skeleton.dm
+++ b/code/modules/mob/living/carbon/human/npc/skeleton/_skeleton.dm
@@ -16,7 +16,7 @@
 	stand_attempts = 4
 	cmode_music = 'sound/music/cmode/antag/combatskeleton.ogg'
 	var/should_have_aggro = TRUE
-	headprice = 7
+	headprice = 14
 
 /mob/living/carbon/human/species/skeleton/npc/no_equipment
 	skel_outfit = null

--- a/code/modules/mob/living/carbon/human/npc/zizombies.dm
+++ b/code/modules/mob/living/carbon/human/npc/zizombies.dm
@@ -51,7 +51,7 @@
 /obj/item/bodypart/l_leg/zizombie
 	dismemberable = 1
 /obj/item/bodypart/head/zizombie
-	sellprice = 5
+	sellprice = 10
 
 /obj/item/bodypart/head/zizombie/update_icon_dropped()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Doubles the sell price of the various animal/monster heads when sold to the Merchant.
- Reduces the money gained from the headeater to 65% of the merchant's sell price.
(This is in preparation of moving the headeater to be immediately outside the Merchant's building.)

## Why It's Good For The Game

Encourages people to go interact with the Merchant (if there is one) so they can sell their monster heads to them. If they're not there though, people can still sell them to the machine for a reduced payout. Encourages ROLEPLAY.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
