### PR TITLE
Etgard Keep and Old Doma Tweaks

### DIFF
--- a/_maps/map_files/domotan/house_templates/manor/lord_bedroom.dmm
+++ b/_maps/map_files/domotan/house_templates/manor/lord_bedroom.dmm
@@ -20,25 +20,27 @@
 /turf/open/floor/carpet/purple,
 /area/indoors/town/keep/lord_appt)
 "n" = (
-/obj/structure/bookcase/random,
+/obj/structure/closet/crate/chest,
+/obj/item/weapon/sword/long/judgement,
+/obj/item/clothing/wrists/bracers/leather,
+/obj/item/clothing/gloves/angle,
+/obj/effect/mapping_helpers/access/keyset/manor/lord,
+/obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/wood,
 /area/indoors/town/keep/lord_appt)
 "o" = (
 /turf/closed/wall/mineral/stonebrick,
 /area/indoors/town/keep/lord_appt)
 "p" = (
-/obj/structure/table/wood{
-	icon_state = "tablewood1"
+/obj/structure/mannequin{
+	name = "regent's display stand"
 	},
-/obj/item/candle/yellow/lit{
-	pixel_x = -9;
-	pixel_y = 14
-	},
+/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal/regent,
 /turf/open/floor/ruinedwood/two,
 /area/indoors/town/keep/lord_appt)
 "u" = (
 /obj/structure/bed/inn/double,
-/obj/item/bedsheet/double_pelt,
+/obj/item/bedsheet/fabric_double,
 /turf/open/floor/carpet/purple,
 /area/indoors/town/keep/lord_appt)
 "y" = (
@@ -59,26 +61,26 @@
 /turf/open/floor/carpet/purple,
 /area/indoors/town/keep/lord_appt)
 "H" = (
-/obj/structure/chair/wood,
+/obj/structure/closet/crate/drawer/random{
+	pixel_y = 10
+	},
+/obj/item/storage/belt/pouch/coins/veryrich,
+/obj/item/storage/belt/pouch/coins/veryrich,
+/obj/item/gem/diamond,
+/obj/item/scomstone,
+/obj/item/scomstone,
+/obj/item/key/lord,
 /turf/open/floor/ruinedwood/two,
 /area/indoors/town/keep/lord_appt)
 "N" = (
-/obj/structure/closet/crate/chest,
-/obj/item/weapon/sword/long/judgement,
-/obj/item/clothing/gloves/angle,
-/obj/item/clothing/wrists/bracers/leather,
+/obj/structure/mannequin{
+	name = "consort's display stand"
+	},
+/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal/consort,
 /turf/open/floor/ruinedwood/two,
 /area/indoors/town/keep/lord_appt)
 "T" = (
-/obj/item/scomstone,
-/obj/item/storage/belt/pouch/coins/mid,
-/obj/item/gem/diamond,
-/obj/item/scomstone,
-/obj/structure/closet/crate/drawer/random{
-	pixel_y = 0
-	},
 /obj/machinery/light/fueled/wallfire/candle/r,
-/obj/item/key/lord,
 /turf/open/floor/carpet/purple,
 /area/indoors/town/keep/lord_appt)
 "Y" = (
@@ -90,7 +92,7 @@
 o
 o
 o
-o
+B
 y
 y
 o
@@ -102,7 +104,7 @@ Y
 f
 e
 e
-B
+o
 "}
 (3,1,1) = {"
 h

--- a/_maps/map_files/domotan/house_templates/manor/vault.dmm
+++ b/_maps/map_files/domotan/house_templates/manor/vault.dmm
@@ -1,10 +1,20 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/glass/bottle/healthpot,
-/obj/item/reagent_containers/glass/bottle/healthpot,
-/obj/item/reagent_containers/glass/bottle/healthpot,
-/obj/item/reagent_containers/glass/bottle/healthpot,
+/obj/item/weapon/sword/decorated{
+	name = "decorated sword";
+	pixel_x = -6;
+	desc = "A trustworthy blade design, the first dedicated tool of war since before the age of history. This one is decorated finely with gold, befitting nobility."
+	},
+/obj/item/weapon/sword/sabre/dec{
+	pixel_x = 6;
+	name = "decorated qadirid sabre"
+	},
+/obj/item/weapon/sword/katana{
+	pixel_x = 16;
+	name = "decorated katana";
+	desc = "A foreign sword, blade honed to a razor's edge. This one is decorated with a golden hilt, befitting nobility."
+	},
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "c" = (
@@ -15,6 +25,19 @@
 	name = "Materials Vault"
 	},
 /turf/open/floor/tile/checkeralt,
+/area/indoors/town/keep)
+"e" = (
+/obj/structure/rack,
+/obj/item/weapon/scabbard/sword/royal,
+/obj/item/weapon/scabbard/sword/royal,
+/obj/item/weapon/scabbard/sword/royal,
+/obj/item/weapon/scabbard/sword/royal,
+/obj/item/weapon/scabbard/sword/royal,
+/obj/item/weapon/scabbard/kazengun/gold{
+	pixel_x = 10;
+	pixel_y = -2
+	},
+/turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "i" = (
 /turf/closed/wall/mineral/stonebrick,
@@ -27,12 +50,12 @@
 	icon_state = "longtable_mid";
 	dir = 1
 	},
-/obj/item/flashlight/flare/torch/metal,
-/obj/item/flashlight/flare/torch/metal,
+/obj/item/weapon/sword/long/exe/cloth{
+	pixel_x = -21;
+	pixel_y = -11;
+	desc = "An heirloom of the Shirleighs, this hefty executioner's blade was said to have belonged to King Malryck in a time long since passed. Now though, it oft lays forgotten in the royal vault."
+	},
 /turf/open/floor/tile/bath,
-/area/indoors/town/keep)
-"x" = (
-/turf/closed/mineral,
 /area/indoors/town/keep)
 "y" = (
 /obj/structure/table/wood{
@@ -40,14 +63,17 @@
 	dir = 1
 	},
 /obj/item/weapon/sword/silver{
-	pixel_x = -12;
-	pixel_y = 13;
-	name = "Miserthorn"
+	pixel_y = 4;
+	name = "Miserthorn";
+	desc = "An heirloom of the Shirleighs, this silver blade is renowned for often being seen at the side of Queen Alyssandrine in years since past."
 	},
-/obj/item/weapon/sword/long/exe/cloth{
-	pixel_x = -21;
-	pixel_y = -11
+/turf/open/floor/tile/bath,
+/area/indoors/town/keep)
+"B" = (
+/obj/structure/mannequin{
+	name = "heir's display stand"
 	},
+/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal,
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "F" = (
@@ -55,6 +81,10 @@
 /obj/machinery/light/fueledstreet/orange/wall{
 	dir = 8
 	},
+/obj/item/reagent_containers/glass/bottle/healthpot,
+/obj/item/reagent_containers/glass/bottle/healthpot,
+/obj/item/reagent_containers/glass/bottle/healthpot,
+/obj/item/reagent_containers/glass/bottle/healthpot,
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "G" = (
@@ -70,8 +100,11 @@
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "J" = (
-/obj/structure/rack,
 /obj/structure/fluff/walldeco/mona,
+/obj/structure/mannequin{
+	name = "heir's display stand"
+	},
+/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal,
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "M" = (
@@ -79,16 +112,27 @@
 	icon_state = "longtable_mid";
 	dir = 1
 	},
-/obj/item/weapon/sword/rapier/dec{
-	pixel_y = -7;
-	pixel_x = -5;
+/obj/item/weapon/sword/rapier/dec/lord{
+	desc = "A royal heirloom of the Shirleighs, forged long ago and of a foreign steel far beyond the Goblet and its lands. Inscribed writing in Old Kui tells that it once belonged to someone named Rash Dequero, and that its implacable edge was driven through the Father of Sin. It gleams with a ferocious intent.";
 	name = "Sin Eater";
-	desc = "A royal heirloom of the Shirleighs, forged long ago and of a foreign steel far beyond the Goblet and its lands. Inscribed writing in Old Kui tells that it once belonged to someone named Rash Dequero, and that its implacable edge was driven through the Father of Sin. It gleams with a ferocious intent."
+	pixel_x = -5;
+	pixel_y = -7
 	},
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "O" = (
 /obj/structure/rack,
+/obj/item/weapon/sword/rapier/dec{
+	pixel_x = -24
+	},
+/obj/item/weapon/sword/long/decorated{
+	pixel_x = -4
+	},
+/obj/item/weapon/sword/long/rider/steppe{
+	pixel_x = -20;
+	name = "decorated steppe sabre";
+	desc = "A curved blade of nomadic origin, it is used by cavalrymen all across the far steppes. This one is decorated with gold, befitting nobility."
+	},
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "Q" = (
@@ -109,6 +153,8 @@
 /obj/machinery/light/fueledstreet/orange/wall{
 	dir = 8
 	},
+/obj/item/flashlight/flare/torch/metal,
+/obj/item/flashlight/flare/torch/metal,
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 
@@ -127,7 +173,7 @@ M
 R
 t
 R
-O
+e
 i
 "}
 (3,1,1) = {"
@@ -146,7 +192,7 @@ t
 t
 t
 a
-x
+i
 "}
 (5,1,1) = {"
 i
@@ -162,7 +208,7 @@ i
 i
 J
 G
-O
+B
 i
 i
 "}

--- a/_maps/map_files/domotan/old_doma_lowpop.dmm
+++ b/_maps/map_files/domotan/old_doma_lowpop.dmm
@@ -8815,11 +8815,10 @@
 /turf/open/floor/dirt/road,
 /area/indoors/town/garrison)
 "gch" = (
-/obj/structure/fake_machine/hailerboard{
-	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
-	},
-/turf/open/floor/blocks/stonered/tiny,
-/area/outdoors/farm)
+/obj/structure/fake_machine/lottery_roguetown,
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/indoors/town/tavern)
 "gcv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -9788,12 +9787,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/cobble,
 /area/indoors/town/vault)
-"gOJ" = (
-/obj/structure/fake_machine/hailerboard{
-	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
-	},
-/turf/open/floor/ruinedwood/two,
-/area/indoors/town/tavern)
 "gPI" = (
 /obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/effect/mapping_helpers/access/locker,
@@ -11581,9 +11574,11 @@
 /turf/open/water/bath,
 /area/indoors/town/bath)
 "hUT" = (
-/obj/machinery/light/fueled/torchholder/c,
-/turf/open/water/ocean,
-/area/under/town/basement/smugglers_den)
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
+/turf/open/floor/blocks/stonered/tiny,
+/area/outdoors/farm)
 "hVw" = (
 /obj/item/flint,
 /obj/structure/table/wood{
@@ -12357,6 +12352,14 @@
 	},
 /turf/open/floor/blocks,
 /area/indoors/town/clinic_large)
+"iti" = (
+/obj/structure/bounty_board{
+	pixel_x = 4;
+	pixel_y = 26;
+	layer = 4.2
+	},
+/turf/open/floor/ruinedwood,
+/area/under/town/basement/smugglers_den)
 "itF" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -17312,6 +17315,12 @@
 "lKy" = (
 /turf/closed/wall/mineral/stone/moss,
 /area/under/town/basement/smugglers_den)
+"lKJ" = (
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
+/turf/open/floor/wood,
+/area/indoors/town/keep/throne)
 "lKL" = (
 /obj/structure/fluff/statue/knight,
 /turf/open/floor/churchmarble,
@@ -19702,12 +19711,6 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/dirt/road,
 /area/outdoors/exposed)
-"neM" = (
-/obj/structure/fake_machine/hailerboard{
-	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
-	},
-/turf/open/floor/wood,
-/area/indoors/town/keep/throne)
 "neU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -34285,9 +34288,10 @@
 /turf/open/floor/ruinedwood/turned,
 /area/indoors/town/tavern)
 "xkI" = (
-/obj/structure/fake_machine/lottery_roguetown,
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
+/turf/open/floor/ruinedwood/two,
 /area/indoors/town/tavern)
 "xkJ" = (
 /obj/item/reagent_containers/food/snacks/crow,
@@ -39418,8 +39422,8 @@ dqL
 nVq
 gmC
 lKy
-tNU
-tNU
+iti
+uEX
 sKV
 gZG
 uEX
@@ -39550,7 +39554,7 @@ fxN
 tKR
 hRL
 lKy
-hUT
+gZG
 gZG
 gZG
 lKy
@@ -61727,7 +61731,7 @@ vKU
 vKU
 fZn
 fZn
-gch
+hUT
 rkh
 gNh
 rNj
@@ -75051,7 +75055,7 @@ dKp
 dKp
 fIP
 dKp
-gOJ
+xkI
 hhL
 xfN
 xfN
@@ -90238,7 +90242,7 @@ bTr
 xnA
 fXt
 xfN
-xkI
+gch
 xnA
 xnA
 kXH
@@ -90370,7 +90374,7 @@ pdl
 xnA
 hPc
 xfN
-xkI
+gch
 xnA
 xnA
 xnA
@@ -92807,7 +92811,7 @@ fNx
 fNx
 fNx
 irS
-neM
+lKJ
 vwN
 vvG
 xSj

--- a/_maps/map_files/domotan/old_doma_lowpop.dmm
+++ b/_maps/map_files/domotan/old_doma_lowpop.dmm
@@ -192,6 +192,8 @@
 /obj/structure/closet/crate/chest,
 /obj/structure/fluff/railing/border,
 /obj/machinery/light/fueled/wallfire/candle/blue,
+/obj/item/soap/bath,
+/obj/item/natural/cloth,
 /turf/open/floor/wood,
 /area/indoors/town/tavern)
 "afS" = (
@@ -2197,6 +2199,9 @@
 /area/indoors/town/clinic_large)
 "bBI" = (
 /obj/structure/table/wood/plain_alt,
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
 /turf/open/floor/blocks/stonered/tiny,
 /area/indoors/town/clinic_large)
 "bBW" = (
@@ -2952,8 +2957,8 @@
 /turf/open/floor/blocks/stonered/tiny,
 /area/indoors/town/clinic_large)
 "ceM" = (
-/obj/item/bedsheet/cloth,
-/obj/structure/bed/inn,
+/obj/structure/bed/inn/double,
+/obj/item/bedsheet/double_pelt,
 /turf/open/floor/ruinedwood/turned,
 /area/indoors/town/tavern)
 "ceU" = (
@@ -5407,7 +5412,6 @@
 /turf/open/floor/church/purple,
 /area/indoors/town/keep/magician/basement)
 "dLd" = (
-/obj/structure/fake_machine/atm,
 /turf/open/floor/ruinedwood/alt,
 /area/outdoors/town/plaza)
 "dLk" = (
@@ -5541,10 +5545,11 @@
 /turf/open/floor/cobble,
 /area/outdoors/town)
 "dQJ" = (
-/obj/machinery/light/fueled/torchholder/r,
-/obj/structure/bed/inn,
-/turf/open/floor/ruinedwood/turned,
-/area/indoors/town/tavern)
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
+/turf/open/floor/ruinedwood,
+/area/outdoors/town)
 "dQL" = (
 /obj/structure/fluff/railing/border{
 	dir = 4
@@ -6174,12 +6179,7 @@
 /area/indoors/town/church)
 "emH" = (
 /obj/structure/closet/crate/chest/neu,
-/obj/item/key/roomi,
-/obj/item/key/roomii,
-/obj/item/key/roomiii,
-/obj/item/key/roomiv,
-/obj/item/key/roomv,
-/obj/item/key/roomvi,
+/obj/effect/spawner/guaranteed_map_spawner/listed/inn_keys/full,
 /turf/open/floor/wood,
 /area/indoors/town/tavern)
 "env" = (
@@ -7057,8 +7057,8 @@
 /turf/open/floor/cobble,
 /area/outdoors/exposed)
 "eQl" = (
-/obj/structure/rack/shelf/biggest{
-	pixel_y = 24
+/obj/structure/fake_machine/vendor/inn{
+	pixel_y = 32
 	},
 /turf/open/floor/wood,
 /area/indoors/town/tavern)
@@ -8815,21 +8815,11 @@
 /turf/open/floor/dirt/road,
 /area/indoors/town/garrison)
 "gch" = (
-/obj/structure/rack/shelf,
-/obj/structure/table/wood{
-	icon_state = "longtable";
-	dir = 1
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
 	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_y = 37;
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/glass/cup/wooden{
-	pixel_y = 37;
-	pixel_x = 5
-	},
-/turf/open/floor/wood,
-/area/indoors/town/tavern)
+/turf/open/floor/blocks/stonered/tiny,
+/area/outdoors/farm)
 "gcv" = (
 /obj/structure/fluff/railing/wood{
 	dir = 4
@@ -9200,6 +9190,9 @@
 "gsw" = (
 /obj/structure/fluff/railing/tall/retaining/stone{
 	dir = 9
+	},
+/obj/structure/fake_machine/hailerboard/r{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
 	},
 /turf/open/floor/cobble,
 /area/outdoors/exposed)
@@ -9795,6 +9788,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/cobble,
 /area/indoors/town/vault)
+"gOJ" = (
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
+/turf/open/floor/ruinedwood/two,
+/area/indoors/town/tavern)
 "gPI" = (
 /obj/effect/mapping_helpers/access/keyset/manor/general,
 /obj/effect/mapping_helpers/access/locker,
@@ -14406,6 +14405,7 @@
 	mailtag = "Merchant";
 	pixel_x = -23
 	},
+/obj/structure/fake_machine/hailerboard,
 /turf/open/floor/tile,
 /area/indoors/town/shop)
 "jLx" = (
@@ -14936,13 +14936,10 @@
 /turf/open/floor/cobble,
 /area/indoors/town/clinic_large)
 "kcW" = (
-/obj/structure/lever{
-	redstone_id = "hoard_shutter";
-	name = "sealing shutter lever";
-	desc = "Curiously positioned on the exterior of the secure area, as opposed to the interior..."
+/obj/structure/lever/hidden/thieves_guild{
+	redstone_id = "divine_gourd"
 	},
-/obj/machinery/light/fueledstreet/blue/wall,
-/turf/open/floor/tile/checkeralt,
+/turf/closed/wall/mineral/stonebrick/reddish,
 /area/indoors/town/vault)
 "kdu" = (
 /obj/structure/fluff/railing/border{
@@ -15698,6 +15695,9 @@
 	pixel_y = 10
 	},
 /obj/structure/table/wood,
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
 /turf/open/floor/ruinedwood/turned,
 /area/indoors/town/church)
 "kAs" = (
@@ -18580,6 +18580,9 @@
 /area/indoors/town/keep/garrison)
 "msp" = (
 /obj/machinery/light/fueled/torchholder/r,
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
 /turf/open/floor/cobble,
 /area/indoors/town/keep)
 "mst" = (
@@ -18906,9 +18909,11 @@
 /turf/open/floor/tile,
 /area/indoors/town/clinic_large)
 "mFn" = (
-/obj/structure/door/weak{
-	name = "Inn Staffers"
+/obj/structure/door/fancy{
+	name = "Staff Backroom"
 	},
+/obj/effect/mapping_helpers/access/keyset/town/inn,
+/obj/effect/mapping_helpers/access/locker,
 /turf/open/floor/herringbone,
 /area/indoors/town/tavern)
 "mFp" = (
@@ -19697,6 +19702,12 @@
 /obj/structure/fluff/statue/tdummy,
 /turf/open/floor/dirt/road,
 /area/outdoors/exposed)
+"neM" = (
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
+/turf/open/floor/wood,
+/area/indoors/town/keep/throne)
 "neU" = (
 /obj/structure/fluff/railing/wood{
 	dir = 1
@@ -20086,6 +20097,10 @@
 "nrF" = (
 /obj/effect/decal/cobbleedge{
 	dir = 6
+	},
+/obj/structure/fake_machine/stockpile{
+	pixel_y = 27;
+	pixel_x = 16
 	},
 /turf/open/floor/ruinedwood,
 /area/outdoors/town/plaza)
@@ -21938,14 +21953,11 @@
 /turf/open/floor/blocks/green,
 /area/indoors/town/keep/kitchen/cellar)
 "oDY" = (
-/obj/structure/fake_machine/stockpile{
-	pixel_y = 27;
-	pixel_x = 16
-	},
 /obj/effect/decal/cobbleedge{
 	dir = 10;
 	icon_state = "cobbleedge-e"
 	},
+/obj/structure/fake_machine/hailer,
 /turf/open/floor/snow,
 /area/outdoors/town/plaza)
 "oEz" = (
@@ -23474,10 +23486,8 @@
 /turf/open/floor/blocks,
 /area/indoors/town/keep/garrison)
 "pIY" = (
-/obj/structure/bounty_board{
-	pixel_x = 4;
-	pixel_y = 30;
-	layer = 4.2
+/obj/structure/fake_machine/mail{
+	mailtag = "Town Square"
 	},
 /turf/open/floor/ruinedwood,
 /area/outdoors/town/plaza)
@@ -24176,8 +24186,19 @@
 /turf/open/floor/dirt/road,
 /area/outdoors/town/neighborhood/east)
 "qkb" = (
-/obj/structure/closet/crate/chest/neu_iron,
-/obj/effect/spawner/guaranteed_map_spawner/listed/inn_keys/full,
+/obj/item/clothing/shoes/sandals,
+/obj/item/clothing/shoes/sandals,
+/obj/item/clothing/shoes/sandals,
+/obj/item/clothing/shoes/sandals,
+/obj/item/natural/feather,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/natural/cloth,
+/obj/item/candle/yellow,
+/obj/item/candle/yellow,
+/obj/item/clothing/shoes/simpleshoes,
+/obj/item/clothing/shoes/shortboots,
+/obj/structure/closet/crate/chest/crate,
 /turf/open/floor/herringbone,
 /area/indoors/town/tavern)
 "qkf" = (
@@ -25754,12 +25775,10 @@
 /turf/closed/wall/mineral/stonebrick,
 /area/indoors/town/vault)
 "rpQ" = (
-/obj/structure/bars/passage/shutter{
-	redstone_id = "hoard_shutter";
-	name = "Divine Hoard Sanctum";
-	desc = "Marred with deep slashes and oozing of the most sinister presence."
+/obj/effect/mapping_helpers/secret_door_creator/keep{
+	redstone_id = "divine_gourd"
 	},
-/turf/open/floor/tile/checkeralt,
+/turf/closed/wall/mineral/stonebrick/reddish,
 /area/indoors/town/vault)
 "rpU" = (
 /obj/machinery/light/fueledstreet/blue/wall{
@@ -27035,6 +27054,9 @@
 /area/under/town/basement/smugglers_den)
 "snt" = (
 /obj/structure/chair/stool,
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
 /turf/open/floor/ruinedwood/spiralfade,
 /area/indoors/town)
 "snB" = (
@@ -29377,6 +29399,9 @@
 /area/indoors/town/waterworks)
 "tTj" = (
 /obj/structure/closet/crate/chest/crate,
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
+	},
 /turf/open/floor/ruinedwood,
 /area/indoors/town/tavern)
 "tTq" = (
@@ -32579,19 +32604,8 @@
 /turf/open/floor/ruinedwood/spiral,
 /area/indoors/town/steward)
 "wfH" = (
-/obj/item/clothing/shoes/sandals,
-/obj/item/clothing/shoes/sandals,
-/obj/item/clothing/shoes/sandals,
-/obj/item/clothing/shoes/sandals,
-/obj/item/natural/feather,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/natural/cloth,
-/obj/item/candle/yellow,
-/obj/item/candle/yellow,
-/obj/item/clothing/shoes/simpleshoes,
-/obj/item/clothing/shoes/shortboots,
-/obj/structure/closet/crate/chest/crate,
+/obj/structure/closet/crate/chest/neu_iron,
+/obj/effect/spawner/guaranteed_map_spawner/listed/inn_keys/full,
 /turf/open/floor/ruinedwood,
 /area/indoors/town/tavern)
 "wgc" = (
@@ -33086,6 +33100,12 @@
 "wtv" = (
 /turf/open/floor/ruinedwood/turned,
 /area/indoors/town/garrison)
+"wtF" = (
+/obj/structure/lever/hidden/thieves_guild{
+	redstone_id = "divine_gourd"
+	},
+/turf/closed/wall/mineral/pipe,
+/area/indoors/town/vault)
 "wtQ" = (
 /obj/structure/fluff/railing/border{
 	dir = 10
@@ -34083,6 +34103,7 @@
 /obj/structure/fluff/railing/wood{
 	dir = 4
 	},
+/obj/structure/fake_machine/atm,
 /turf/open/floor/ruinedwood,
 /area/outdoors/town/plaza)
 "xda" = (
@@ -34264,11 +34285,8 @@
 /turf/open/floor/ruinedwood/turned,
 /area/indoors/town/tavern)
 "xkI" = (
-/obj/structure/table/wood{
-	dir = 1;
-	icon_state = "longtable_mid"
-	},
-/obj/structure/fake_machine/vendor/inn,
+/obj/structure/fake_machine/lottery_roguetown,
+/obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/indoors/town/tavern)
 "xkJ" = (
@@ -34911,9 +34929,11 @@
 /turf/open/floor/tile/checkeralt,
 /area/indoors/town/keep/kitchen/cellar)
 "xHr" = (
-/obj/structure/fake_machine/hailerboard,
 /obj/effect/decal/cobbleedge{
 	icon_state = "cobbleedge-n"
+	},
+/obj/structure/fake_machine/hailerboard{
+	desc = "A notice board that shows all the notices the Adventurer's Guild has put up. Want to post your own? Look for the HAILER in the town square!"
 	},
 /turf/open/floor/snow,
 /area/outdoors/town/plaza)
@@ -60735,7 +60755,7 @@ tMC
 rpm
 alA
 alA
-alA
+wtF
 rpm
 iUL
 kVN
@@ -60873,7 +60893,7 @@ tGT
 kVN
 kVN
 tGT
-rpm
+kcW
 rpm
 nKu
 jdz
@@ -60999,9 +61019,9 @@ tMC
 rpm
 alA
 alA
-alA
+wtF
 rpm
-kcW
+iUL
 kVN
 kVN
 jPa
@@ -61707,7 +61727,7 @@ vKU
 vKU
 fZn
 fZn
-rkh
+gch
 rkh
 gNh
 rNj
@@ -73986,7 +74006,7 @@ aFc
 vrp
 oLs
 eup
-jgF
+dQJ
 olG
 uWy
 mrR
@@ -75031,7 +75051,7 @@ dKp
 dKp
 fIP
 dKp
-hhL
+gOJ
 hhL
 xfN
 xfN
@@ -90076,13 +90096,13 @@ fNx
 fNx
 fNx
 dvc
-xfN
+pdl
 tBS
 qqt
-xfN
+pdl
 oBR
 qqt
-xfN
+pdl
 afY
 qqt
 xfN
@@ -90208,13 +90228,13 @@ fNx
 fNx
 fNx
 dvc
-xfN
+bTr
 xnA
 fXt
-xfN
+bTr
 xnA
 fXt
-xfN
+bTr
 xnA
 fXt
 xfN
@@ -90340,17 +90360,17 @@ fNx
 fNx
 fNx
 dvc
-xfN
+pdl
+xnA
+hPc
+pdl
+xnA
+hPc
+pdl
 xnA
 hPc
 xfN
-xnA
-hPc
-xfN
-xnA
-hPc
-xfN
-gch
+xkI
 xnA
 xnA
 xnA
@@ -91264,7 +91284,7 @@ fNx
 fNx
 fNx
 dvc
-xfN
+pdl
 ifj
 ifj
 ifj
@@ -91396,7 +91416,7 @@ fNx
 fNx
 fNx
 bvv
-xfN
+pdl
 arw
 ifj
 ifj
@@ -92786,8 +92806,8 @@ fNx
 fNx
 fNx
 fNx
-fVf
-tiw
+irS
+neM
 vwN
 vvG
 xSj
@@ -106710,7 +106730,7 @@ fNx
 fNx
 fNx
 dvc
-xfN
+bTr
 cTE
 vOp
 vOp
@@ -106987,7 +107007,7 @@ cPk
 ifj
 ifj
 ifj
-xfN
+bTr
 fNx
 fNx
 fNx
@@ -107238,7 +107258,7 @@ fNx
 fNx
 fNx
 dvc
-xfN
+bTr
 jBI
 dsB
 dsB
@@ -107372,7 +107392,7 @@ fNx
 dvc
 noo
 ceM
-dQJ
+pry
 ceM
 xfN
 hhL
@@ -107383,7 +107403,7 @@ xfN
 xfN
 ifj
 ifj
-pdl
+bTr
 fNx
 fNx
 dvc
@@ -107766,7 +107786,7 @@ fNx
 fNx
 fNx
 dvc
-pdl
+bTr
 xwm
 dsB
 dsB
@@ -107779,7 +107799,7 @@ vOp
 xfN
 ifj
 ifj
-pdl
+bTr
 fNx
 fNx
 dvc

--- a/code/game/objects/effects/spawners/guaranteed_map_spawner/spawners.dm
+++ b/code/game/objects/effects/spawners/guaranteed_map_spawner/spawners.dm
@@ -187,6 +187,42 @@
 		/obj/item/storage/belt/leather = 1,
 	)
 
+/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal
+	name = "Heir Armor Set Spawner"
+	spawned = list(
+		/obj/item/clothing/head/helmet/visored/sallet = 1,
+		/obj/item/clothing/neck/chaincoif = 1,
+		/obj/item/clothing/armor/cuirass = 1,
+		/obj/item/clothing/armor/gambeson/hunts = 1,
+		/obj/item/clothing/gloves/leather/advanced = 1,
+		/obj/item/clothing/pants/trou/leather/guard = 1,
+		/obj/item/clothing/shoes/boots/leather/advanced = 1,
+	)
+
+/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal/regent
+	name = "Regent Armor Set Spawner"
+	spawned = list(
+		/obj/item/clothing/head/helmet/heavy/decorated/hounskull = 1,
+		/obj/item/clothing/neck/chaincoif = 1,
+		/obj/item/clothing/armor/plate/decorated = 1,
+		/obj/item/clothing/armor/gambeson/hunts = 1,
+		/obj/item/clothing/gloves/plate = 1,
+		/obj/item/clothing/pants/platelegs = 1,
+		/obj/item/clothing/shoes/boots/armor = 1,
+	)
+
+/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal/consort
+	name = "Consort Armor Set Spawner"
+	spawned = list(
+		/obj/item/clothing/head/helmet/heavy/decorated/bascinet = 1,
+		/obj/item/clothing/neck/chaincoif = 1,
+		/obj/item/clothing/armor/plate/decorated = 1,
+		/obj/item/clothing/armor/gambeson/hunts = 1,
+		/obj/item/clothing/gloves/chain = 1,
+		/obj/item/clothing/pants/chainlegs = 1,
+		/obj/item/clothing/shoes/boots/armor = 1,
+	)
+
 /obj/effect/spawner/guaranteed_map_spawner/listed/weapons
 	name = "Crude Weapons Spawner"
 	icon_state = "weapon_spawner"

--- a/code/game/objects/items/keyrings.dm
+++ b/code/game/objects/items/keyrings.dm
@@ -222,6 +222,9 @@
 /obj/item/storage/keyring/consort
 	keys = list(/obj/item/key/dungeon, /obj/item/key/atarms, /obj/item/key/walls, /obj/item/key/manor, /obj/item/key/consort, /obj/item/key/guest)
 
+/obj/item/storage/keyring/heir
+	keys = list(/obj/item/key/dungeon, /obj/item/key/garrison, /obj/item/key/forrestgarrison, /obj/item/key/atarms, /obj/item/key/walls, /obj/item/key/manor, /obj/item/key/guest, /obj/item/key/vault)
+
 /obj/item/storage/keyring/guard
 	keys = list(/obj/item/key/garrison)
 
@@ -229,7 +232,7 @@
 	keys = list(/obj/item/key/garrison, /obj/item/key/lieutenant)
 
 /obj/item/storage/keyring/manorguard
-	keys = list(/obj/item/key/manor, /obj/item/key/dungeon, /obj/item/key/atarms, /obj/item/key/walls)
+	keys = list(/obj/item/key/manor, /obj/item/key/dungeon, /obj/item/key/atarms, /obj/item/key/walls, /obj/item/key/garrison)
 
 /obj/item/storage/keyring/archivist
 	keys = list(/obj/item/key/archive, /obj/item/key/manor)

--- a/code/game/objects/items/keys.dm
+++ b/code/game/objects/items/keys.dm
@@ -307,7 +307,7 @@
 /obj/item/key/consort
 	name = "consort key"
 	desc = "The Consort's key."
-	icon_state = "mazekey"
+	icon_state = "cheesekey"
 	lockids = list(ACCESS_LORD)
 
 /obj/item/key/walls

--- a/code/game/objects/structures/fake_machines/vendor.dm
+++ b/code/game/objects/structures/fake_machines/vendor.dm
@@ -278,12 +278,12 @@
 		var/obj/I = new X(src)
 		held_items[I] = list()
 		held_items[I]["NAME"] = I.name
-		held_items[I]["PRICE"] = 20
-	for(var/X in list(/obj/item/key/luxroomi))
+		held_items[I]["PRICE"] = 10
+	for(var/X in list(/obj/item/key/luxroomi, /obj/item/key/luxroomii, /obj/item/key/luxroomiii))
 		var/obj/I = new X(src)
 		held_items[I] = list()
 		held_items[I]["NAME"] = I.name
-		held_items[I]["PRICE"] = 60
+		held_items[I]["PRICE"] = 40
 
 /obj/structure/fake_machine/vendor/steward
 	lockids = list(ACCESS_STEWARD)

--- a/code/modules/jobs/job_types/adventurer/types/wretch/reject.dm
+++ b/code/modules/jobs/job_types/adventurer/types/wretch/reject.dm
@@ -38,9 +38,6 @@
 
 	attribute_sheet = /datum/attribute_holder/sheet/job/reject
 
-	mind_traits = list(
-		TRAIT_KNOW_KEEP_DOORS
-	)
 	traits = list(
 		TRAIT_BEAUTIFUL,
 		TRAIT_DODGEEXPERT,

--- a/code/modules/jobs/job_types/apprentices/prince.dm
+++ b/code/modules/jobs/job_types/apprentices/prince.dm
@@ -105,7 +105,7 @@
 	shoes = /obj/item/clothing/shoes/nobleboot
 	belt = /obj/item/storage/belt/leather
 	beltl = /obj/item/weapon/sword
-	beltr = /obj/item/key/manor
+	beltr = /obj/item/storage/keyring/heir
 	neck = /obj/item/storage/belt/pouch/coins/rich
 	backr = /obj/item/storage/backpack/satchel
 
@@ -163,7 +163,7 @@
 /datum/outfit/heir/aristocrat
 	name = "Unawakened Blood (Prince)"
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/key/manor
+	beltl = /obj/item/storage/keyring/heir
 	beltr = /obj/item/storage/belt/pouch/coins/rich
 
 /datum/outfit/heir/aristocrat/pre_equip(mob/living/carbon/human/equipped_human, visuals_only)

--- a/code/modules/jobs/job_types/nobility/archivist.dm
+++ b/code/modules/jobs/job_types/nobility/archivist.dm
@@ -43,9 +43,6 @@
 		/datum/language/deepspeak
 	)
 
-	mind_traits = list(
-		TRAIT_KNOW_KEEP_DOORS
-	)
 	traits = list(
 		TRAIT_NOBLE_BLOOD,
 		TRAIT_NOBLE_POWER,

--- a/code/modules/jobs/job_types/nobility/consort.dm
+++ b/code/modules/jobs/job_types/nobility/consort.dm
@@ -61,7 +61,7 @@
 	shoes = /obj/item/clothing/shoes/boots
 	ring = /obj/item/clothing/ring/silver
 	belt = /obj/item/storage/belt/leather
-	beltl = /obj/item/storage/keyring/consort
+	beltl = /obj/item/key/consort
 	beltr = /obj/item/storage/belt/pouch/coins/rich
 
 /* ! ! ! CONSORT CLASSES ! ! !

--- a/code/modules/jobs/job_types/nobility/hand.dm
+++ b/code/modules/jobs/job_types/nobility/hand.dm
@@ -30,9 +30,6 @@
 	honorary = "Lord"
 	honorary_f = "Lady"
 
-	mind_traits = list(
-		TRAIT_KNOW_KEEP_DOORS
-	)
 	traits = list(
 		TRAIT_NOBLE_BLOOD,
 		TRAIT_NOBLE_POWER,

--- a/code/modules/jobs/job_types/peasants/butler.dm
+++ b/code/modules/jobs/job_types/peasants/butler.dm
@@ -54,7 +54,6 @@
 	attribute_sheet = /datum/attribute_holder/sheet/job/butler
 
 	mind_traits = list(
-		TRAIT_KNOW_KEEP_DOORS,
 		TRAIT_ROYALSERVANT
 	)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Adds sets of armour for the Regent and Consort in their room.
- Adds two sets of armour for royal Heirs to the vault.
- Adds various cultural swords to the vault for the royal family to use.
- Places the Divine Hoard behind a secret wall that only the royal family can open.
- Removes the evil contract board from the town square and places a HAILER machine there next to the HAILER BOARD.
- Places multiple HAILER BOARDS throughout town to make it easier for people to request help and advertise services.
- Adds two of the Iliope gambling machines to the upstairs Inn.
- Properly adds the Inn room keys to the PEDDLER upstairs so people can rent the rooms.
- Puts the chest full of spare inn keys behind the locked staff door so people can't just take them for free rooms.
- Lowers the cost of the Inn room keys a little bit so they're a little more affordable.
- Fixes #108.

## Why It's Good For The Game

fun. soul even.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
map: Adds sets of armour for the Regent and Consort in their room.
map: Adds two sets of armour for royal Heirs to the vault.
map: Adds various cultural swords to the vault for the royal family to use.
map: Places the Divine Hoard behind a secret wall that only the royal family can open.
map: Removes the evil contract board from the town square and places a HAILER machine there next to the HAILER BOARD.
map: Places multiple HAILER BOARDS throughout town to make it easier for people to request help and advertise services.
map: Adds two of the Iliope gambling machines to the upstairs Inn.
map: Puts the chest full of spare inn keys behind the locked staff door so people can't just take them for free rooms.
fix: Properly adds the Inn room keys to the PEDDLER upstairs so people can rent the rooms.
fix: Lowers the cost of the Inn room keys a little bit so they're a little more affordable.
fix: Fixes #108.
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
