### PR TITLE
Removes smell causing vomiting, removes stress event screaming

### DIFF
--- a/code/datums/quirks/vices/physical_vice.dm
+++ b/code/datums/quirks/vices/physical_vice.dm
@@ -433,7 +433,6 @@
 
 		if(world.time >= next_panic)
 			next_panic = world.time + 8 SECONDS
-			owner.emote("scream")
 			var/move_dir = pick(GLOB.cardinals)
 			step(owner, move_dir)
 

--- a/code/datums/status_effects/debuffs/phobia.dm
+++ b/code/datums/status_effects/debuffs/phobia.dm
@@ -6,7 +6,6 @@
 
 /datum/status_effect/minor_phobia_reaction/on_apply()
 	. = ..()
-	owner.emote("scream")
 	owner.adjust_jitter(12 SECONDS)
 	owner.add_stress(/datum/stress_event/startled)
 
@@ -45,10 +44,6 @@
 			to_chat(owner, span_warning("You are startled!"))
 			owner.emote("jump")
 			owner.Immobilize(0.1 SECONDS * stacks)
-
-		if(2)
-			owner.emote("scream")
-			owner.say("AAAAH!!", forced = "phobia")
 
 			if(stacks >= 5)
 				var/held_item = owner.get_active_held_item()

--- a/code/modules/surgery/organs/internal/stomach.dm
+++ b/code/modules/surgery/organs/internal/stomach.dm
@@ -87,7 +87,7 @@
 
 /obj/item/organ/stomach/proc/handle_disgust(mob/living/carbon/human/H)
 	if(H.disgust)
-		var/pukeprob = 5 + 0.05 * H.disgust
+		var/stutterprob = 5 + 0.05 * H.disgust
 		if(H.disgust >= DISGUST_LEVEL_GROSS)
 			if(prob(10))
 				H.stuttering += 1
@@ -96,10 +96,9 @@
 				to_chat(H, "<span class='warning'>I feel kind of iffy...</span>")
 			H.adjust_jitter(-6 SECONDS)
 		if(H.disgust >= DISGUST_LEVEL_VERYGROSS)
-			if(prob(pukeprob)) //iT hAndLeS mOrE ThaN PukInG
+			if(prob(stutterprob)) //this doesnt make you vomit anymore
 				H.adjust_confusion(5 SECONDS)
 				H.stuttering += 1
-				H.vomit(10, 0, 1, 0, 1, 0)
 			H.set_dizzy(10 SECONDS)
 		if(H.disgust >= DISGUST_LEVEL_DISGUSTED)
 			if(prob(25))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Title. Here's two funny situations that happen way too frequently:
1. Step into a room that barely crosses the "too dark" threshold and immediately scream bloody murder
and
2. Someone didn't take a bath and walked through town once or twice and now there is vomit literally everywhere.

Both of these are disruptive, annoying and poopshit. The accompanying stress events are beyond plenty for our purposes.

## Why It's Good For The Game

sometimes i wonder if the poop humor is actually humor or if people actually enjoy this sort of shit in a video game

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
del: Removed vomiting from smell mechanics.
del: Removed spontaneous uncontrollable screaming from most selectable phobias.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
