### PR TITLE
Fixes Royal Armour Mannequins

### DIFF
--- a/_maps/map_files/domotan/house_templates/manor/lord_bedroom.dmm
+++ b/_maps/map_files/domotan/house_templates/manor/lord_bedroom.dmm
@@ -32,10 +32,15 @@
 /turf/closed/wall/mineral/stonebrick,
 /area/indoors/town/keep/lord_appt)
 "p" = (
-/obj/structure/mannequin{
-	name = "regent's display stand"
-	},
-/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal/regent,
+/obj/structure/mannequin/male,
+/obj/item/clothing/shoes/boots/armor,
+/obj/item/clothing/pants/platelegs,
+/obj/item/clothing/gloves/plate,
+/obj/item/clothing/armor/gambeson/hunts,
+/obj/item/clothing/armor/plate/decorated,
+/obj/item/clothing/neck/chaincoif,
+/obj/item/clothing/head/helmet/heavy/decorated/hounskull,
+/obj/item/storage/belt/leather/plaquegold,
 /turf/open/floor/ruinedwood/two,
 /area/indoors/town/keep/lord_appt)
 "u" = (
@@ -73,10 +78,15 @@
 /turf/open/floor/ruinedwood/two,
 /area/indoors/town/keep/lord_appt)
 "N" = (
-/obj/structure/mannequin{
-	name = "consort's display stand"
-	},
-/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal/consort,
+/obj/structure/mannequin/male,
+/obj/item/clothing/shoes/boots/armor,
+/obj/item/clothing/pants/chainlegs,
+/obj/item/clothing/gloves/chain,
+/obj/item/clothing/armor/gambeson/hunts,
+/obj/item/clothing/armor/plate/decorated,
+/obj/item/clothing/neck/chaincoif,
+/obj/item/clothing/head/helmet/heavy/decorated/bascinet,
+/obj/item/storage/belt/leather/plaquegold,
 /turf/open/floor/ruinedwood/two,
 /area/indoors/town/keep/lord_appt)
 "T" = (

--- a/_maps/map_files/domotan/house_templates/manor/vault.dmm
+++ b/_maps/map_files/domotan/house_templates/manor/vault.dmm
@@ -70,10 +70,15 @@
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "B" = (
-/obj/structure/mannequin{
-	name = "heir's display stand"
-	},
-/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal,
+/obj/structure/mannequin/male,
+/obj/item/clothing/shoes/boots/leather/advanced,
+/obj/item/clothing/pants/trou/leather/advanced,
+/obj/item/clothing/armor/gambeson/hunts,
+/obj/item/clothing/gloves/leather/advanced,
+/obj/item/clothing/armor/cuirass,
+/obj/item/clothing/head/helmet/visored/sallet,
+/obj/item/storage/belt/leather/plaquesilver,
+/obj/item/clothing/neck/chaincoif,
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "F" = (
@@ -101,10 +106,15 @@
 /area/indoors/town/keep)
 "J" = (
 /obj/structure/fluff/walldeco/mona,
-/obj/structure/mannequin{
-	name = "heir's display stand"
-	},
-/obj/effect/spawner/guaranteed_map_spawner/listed/armor/royal,
+/obj/structure/mannequin/male,
+/obj/item/clothing/shoes/boots/leather/advanced,
+/obj/item/clothing/pants/trou/leather/advanced,
+/obj/item/clothing/armor/gambeson/hunts,
+/obj/item/clothing/gloves/leather/advanced,
+/obj/item/clothing/armor/cuirass,
+/obj/item/clothing/head/helmet/visored/sallet,
+/obj/item/storage/belt/leather/plaquesilver,
+/obj/item/clothing/neck/chaincoif,
 /turf/open/floor/tile/bath,
 /area/indoors/town/keep)
 "M" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Manually maps the armour for the mannequins into the game instead of using the spawners, so they actually click onto the mannequin instead of being in a pile.

## Why It's Good For The Game

It looks silly when the armour is just on a pile.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
map: Swaps the spawners for the royal armour with manually mapping the armour pieces onto the mannequins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
