### PR TITLE
Armour Rebalancing

### DIFF
--- a/code/game/objects/effects/spawners/guaranteed_map_spawner/spawners.dm
+++ b/code/game/objects/effects/spawners/guaranteed_map_spawner/spawners.dm
@@ -165,7 +165,7 @@
 		/obj/item/clothing/wrists/bracers/ironjackchain = 1,//iron chain bracers
 		/obj/item/clothing/shoes/boots/armor/ironmaille = 1,//iron chain shoes
 		/obj/item/clothing/pants/chainlegs = 1,//steel chain pants
-		/obj/item/clothing/armor/brigandine = 1,
+		/obj/item/clothing/armor/brigandine/light = 1,
 		/obj/item/clothing/armor/chainmail/hauberk = 1,
 		/obj/item/clothing/armor/chainmail/hauberk/fluted = 1,
 		/obj/item/clothing/armor/chainmail/hauberk/gronn = 1,
@@ -181,7 +181,7 @@
 		/obj/item/clothing/wrists/bracers/iron = 1,//iron plate bracers
 		/obj/item/clothing/shoes/boots/armor/light = 1,//iron plate boots
 		/obj/item/clothing/pants/chainlegs/kilt = 1,//steel kilt
-		/obj/item/clothing/armor/plate = 1,//steel halfplate
+		/obj/item/clothing/armor/brigandine = 1,//steel halfplate
 		/obj/item/clothing/gloves/plate/iron = 1,//iron plate gloves
 		/obj/item/clothing/neck/gorget = 1,//iron neck gorget
 		/obj/item/storage/belt/leather = 1,

--- a/code/modules/jobs/job_types/church/templar.dm
+++ b/code/modules/jobs/job_types/church/templar.dm
@@ -7,7 +7,6 @@
 		/datum/attribute/skill/combat/wrestling = 30,
 		/datum/attribute/skill/combat/unarmed = 20,
 		/datum/attribute/skill/combat/shields = 30,
-		/datum/attribute/skill/combat/swords = 40,
 		/datum/attribute/skill/misc/climbing = 10,
 		/datum/attribute/skill/misc/athletics = 30,
 		/datum/attribute/skill/misc/reading = 20,
@@ -201,7 +200,7 @@
 	name = JOB_TEMPLAR
 	head = /obj/item/clothing/head/helmet/heavy/necked
 	cloak = /obj/item/clothing/cloak/tabard/crusader/tief
-	armor = /obj/item/clothing/armor/plate
+	armor = /obj/item/clothing/armor/brigandine
 	shirt = /obj/item/clothing/armor/chainmail
 	pants = /obj/item/clothing/pants/chainlegs
 	shoes = /obj/item/clothing/shoes/boots/armor/light

--- a/code/modules/jobs/job_types/garrison/men_at_arms.dm
+++ b/code/modules/jobs/job_types/garrison/men_at_arms.dm
@@ -142,7 +142,7 @@
 /datum/outfit/watchman/axeman
 	name = "Axeman Men-At-Arms"
 	head = /obj/item/clothing/head/helmet/kettle/slit/atarms
-	armor = /obj/item/clothing/armor/brigandine
+	armor = /obj/item/clothing/armor/brigandine/light
 	shirt = /obj/item/clothing/armor/gambeson/heavy
 	neck = /obj/item/clothing/neck/bevor
 	gloves = /obj/item/clothing/gloves/chain

--- a/code/modules/jobs/job_types/garrison/royal_knight.dm
+++ b/code/modules/jobs/job_types/garrison/royal_knight.dm
@@ -115,14 +115,18 @@
 /datum/outfit/royalknight
 	name = "Royal Knight Base"
 	neck = /obj/item/clothing/neck/chaincoif
-	pants = /obj/item/clothing/pants/platelegs
+	pants = /obj/item/clothing/pants/chainlegs
 	cloak = /obj/item/clothing/cloak/tabard/knight/guard
 	shirt = /obj/item/clothing/armor/gambeson/arming
-	wrists = /obj/item/storage/keyring/manorguard
+	wrists = /obj/item/clothing/wrists/bracers/jackchain
 	belt = /obj/item/storage/belt/leather
 	beltr = /obj/item/weapon/sword/arming
 	backl = /obj/item/storage/backpack/satchel
 	scabbards = list(/obj/item/weapon/scabbard/sword/noble)
+
+	backpack_contents = list(
+		/obj/item/storage/keyring/manorguard,
+	)
 
 /datum/outfit/royalknight/post_equip(mob/living/carbon/human/H, visuals_only = FALSE)
 	. = ..()
@@ -163,9 +167,9 @@
 
 /datum/outfit/royalknight/knight
 	name = JOB_ROYAL_KNIGHT
-	armor = /obj/item/clothing/armor/plate/full
-	gloves = /obj/item/clothing/gloves/plate
-	shoes = /obj/item/clothing/shoes/boots/armor
+	armor = /obj/item/clothing/armor/brigandine
+	gloves = /obj/item/clothing/gloves/chain
+	shoes = /obj/item/clothing/shoes/boots/armor/light
 
 // Helmet Selection (Royal Knight Exclusive)
 /datum/job/advclass/royalknight/knight/on_roundstart(mob/living/carbon/human/spawned, client/player_client)

--- a/code/modules/jobs/job_types/nobility/captain.dm
+++ b/code/modules/jobs/job_types/nobility/captain.dm
@@ -112,7 +112,7 @@
 	pants = /obj/item/clothing/pants/platelegs/captain
 	armor = /obj/item/clothing/armor/brigandine/captain
 	neck = /obj/item/clothing/neck/gorget
-	shirt = /obj/item/clothing/shirt/undershirt/colored/guard
+	shirt = /obj/item/clothing/armor/gambeson/heavy
 	shoes = /obj/item/clothing/shoes/boots
 	backl = /obj/item/storage/backpack/satchel
 	belt = /obj/item/storage/belt/leather/plaquesilver


### PR DESCRIPTION
## About The Pull Request

Lowers the quality of armour across the towner jobs somewhat.

## Why It's Good For The Game

Higher quality armour was good when the playtest began and people were trying to find their feet again with Roguetown, especially with the combat; but everyone's rather well-situated now, and certain jobs (Garrison and Church) have armour that's starting to become a little bit impossible to do anything against.

Lowering the armour is good because it actually makes people vulnerable again instead of walking unassailable fortresses. It gives doctors something to actually do, it gives antagonists and dungeon monsters a chance, and it makes players think twice before jumping headfirst into the Terrorbog because they have steel armour.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: Dropped Royal Knight's Steel full-plate to Brigandine.
balance: Dropped Royal Knight's plate vambraces to jackchain.
balance: Dropped Royal Knight's plate gloves to chain gloves.
balance: Dropped Royal Knight's plate leggings to chain chausses.
balance: Dropped Royal Knight's plate boots to light plate boots.
balance: Dropped Axeman Man-at-Arms' Brigandine to Light Brigandine.
balance: Dropped Templar's Steel half-plate to Brigandine.
balance: Dropped the Steel half-plate in the Heavy Templar Armour Spawner to Brigandine.
balance: Dropped the Brigandine in the Templar Armour Spawner to Light Brigandine.
balance: Swapped the t-shirt that the Captain spawns in with for a gambeson underneath their Brigandine, bringing them more in-line with Royal Knight.
fix: Fixed the bug granting Templars a whopping 80 skill level with swords if they picked a deity that granted extra sword skill.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
