### PR TITLE
Wretch Spawn Fix

### DIFF
--- a/code/modules/antagonists/villain/wretch.dm
+++ b/code/modules/antagonists/villain/wretch.dm
@@ -22,7 +22,18 @@
 	. = ..()
 	W.reset_and_reroll_stats()
 	owner.special_role = ROLE_WRETCH
-	SSrole_class_handler.setup_class_handler(W, list(CTAG_WRETCH = 30))
+
+	if(W.client)
+		SSrole_class_handler.setup_class_handler(W, list(CTAG_WRETCH = 30))
+	else
+		RegisterSignal(W, COMSIG_MOB_LOGIN, PROC_REF(on_wretch_login))
+
+/datum/antagonist/wretch/proc/on_wretch_login()
+	SIGNAL_HANDLER
+	var/mob/living/carbon/human/W = owner.current
+	UnregisterSignal(W, COMSIG_MOB_LOGIN)
+	if(W.client)
+		SSrole_class_handler.setup_class_handler(W, list(CTAG_WRETCH = 30))
 
 /datum/antagonist/wretch/greet()
 	to_chat(owner.current, span_notice("Somewhere in your lyfe, you fell to the wrong side of civilization. Hounded by the consequences of your actions, you now threaten the peace of those who still heed the authority that condemned you."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Makes it so wretch is no longer frozen when spawning in after readying up for the round.
Fixes #234 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
wretch can now ready up, thas good

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
fix: Wretch can now spawn after readying up for the round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
