### PR TITLE
Add Beespider & Goat to Loyal Companion options

### DIFF
--- a/code/datums/quirks/boon/_boon.dm
+++ b/code/datums/quirks/boon/_boon.dm
@@ -95,6 +95,7 @@
 		/mob/living/simple_animal/hostile/retaliate/chicken,
 		/mob/living/simple_animal/hostile/retaliate/fox,
 		/mob/living/simple_animal/hostile/retaliate/raccoon,
+		/mob/living/simple_animal/hostile/retaliate/spider
 	)
 
 	/// Reference to the spawned pet

--- a/code/datums/quirks/boon/_boon.dm
+++ b/code/datums/quirks/boon/_boon.dm
@@ -93,6 +93,7 @@
 		/mob/living/simple_animal/pet/cat/black,
 		/mob/living/simple_animal/hostile/retaliate/frog,
 		/mob/living/simple_animal/hostile/retaliate/chicken,
+		/mob/living/simple_animal/hostile/retaliate/goatmale
 		/mob/living/simple_animal/hostile/retaliate/fox,
 		/mob/living/simple_animal/hostile/retaliate/raccoon,
 		/mob/living/simple_animal/hostile/retaliate/spider


### PR DESCRIPTION
What it do:
Adds "Beespider" as an option as a the boon "Loyal Companion" to spawn with a skitterish friend.
Edit: Goat added as an optional pet to the list.

Why Good for Game:
More option, drow players and spider lovers rejoice.

Changelog:
add: /spider to options of boon/pet (1 line change)

Pre-Merge Checklist:
Local tested? yes
Runtime? no
Documented changes? yes
Broke down learning this? maybe