### PR TITLE
Ability to Sew Through Armor

### DIFF
--- a/code/game/objects/items/needle.dm
+++ b/code/game/objects/items/needle.dm
@@ -207,11 +207,16 @@
 	if(stringamt < 1)
 		to_chat(user, span_warning("The needle has no thread left!"))
 		return FALSE
+	var/armor_mod
 	var/mob/living/doctor = user
 	var/mob/living/carbon/patient = target
 	if(!get_location_accessible(patient, check_zone(doctor.zone_selected)))
-		to_chat(doctor, span_warning("Something is in the way."))
-		return FALSE
+		if(GET_MOB_SKILL_VALUE(doctor, /datum/attribute/skill/misc/medicine) >= 35)
+			to_chat(doctor, span_notice("I'm skilled enough to sew through this.."))
+			armor_mod = calculate_armor_mod(patient, doctor.zone_selected)
+		else
+			to_chat(doctor, span_warning("I'm not skilled enough to sew through this!"))
+			return FALSE
 	var/obj/item/bodypart/affecting = patient.get_bodypart(check_zone(doctor.zone_selected))
 	if(!affecting)
 		to_chat(doctor, span_warning("That limb is missing."))
@@ -226,6 +231,8 @@
 	// First try to fix arteries
 	if(affecting.get_cut() && affecting.is_artery_torn())
 		var/time = 5 SECONDS
+		if(armor_mod)
+			time += armor_mod*10
 		time *= perception_mod * doctor_mod
 		playsound(patient, 'sound/foley/sewflesh.ogg', 100, TRUE, -2)
 		if(!do_after(doctor, time, patient))
@@ -265,6 +272,8 @@
 		if(injury.is_sutured())
 			continue
 		var/time = 2 SECONDS + min(injury.damage_per_injury() * 0.1, 2 SECONDS)
+		if(armor_mod)
+			time += armor_mod*10
 		time *= perception_mod * doctor_mod
 		playsound(target, 'sound/foley/sewflesh.ogg', 65, FALSE)
 		if(!do_after(user, time, target))

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -117,3 +117,13 @@
 				return TRUE
 
 	return FALSE
+
+/proc/calculate_armor_mod(mob/living/carbon/H, target_zone)
+	var/total_weight = 0
+
+	for(var/obj/item/equipped_item in H.get_equipped_items())
+		if(zone2covered(target_zone, equipped_item.body_parts_covered) && equipped_item.surgery_cover)
+			if(equipped_item.w_class)
+				total_weight += equipped_item.w_class
+
+	return total_weight

--- a/code/modules/surgery/surgery_helpers.dm
+++ b/code/modules/surgery/surgery_helpers.dm
@@ -118,6 +118,7 @@
 
 	return FALSE
 
+// specifically used for /obj/item/needle/proc/sew_wounds
 /proc/calculate_armor_mod(mob/living/carbon/H, target_zone)
 	var/total_weight = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Adds the ability to sew through clothing and armor at a debuffed time.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes healing life easier

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Ability to sew through clothing and armor!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
